### PR TITLE
removed double correction

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -138,8 +138,8 @@ function onEntityLeftDragStart(wrapped, event) {
 	ruler.draggedEntity = this;
 	const entityCenter = getEntityCenter(this);
 	ruler.rulerOffset = {
-		x: entityCenter.x - event.interactionData.origin.x,
-		y: entityCenter.y - event.interactionData.origin.y,
+		x: 0,
+		y: 0,
 	};
 	if (game.settings.get(settingsKey, "autoStartMeasurement")) {
 		let options = {};

--- a/src/main.js
+++ b/src/main.js
@@ -138,10 +138,10 @@ function onEntityLeftDragStart(wrapped, event) {
 	ruler.draggedEntity = this;
 	const entityCenter = getEntityCenter(this);
 	const isV11 = game.release.generation === 11;
-    ruler.rulerOffset = {
-    	x: isV11 ? entityCenter.x - event.interactionData.origin.x : 0,
-      	y: isV11 ? entityCenter.y - event.interactionData.origin.y : 0,
-    };
+	ruler.rulerOffset = {
+		x: isV11 ? entityCenter.x - event.interactionData.origin.x : 0,
+		y: isV11 ? entityCenter.y - event.interactionData.origin.y : 0,
+	};
 	if (game.settings.get(settingsKey, "autoStartMeasurement")) {
 		let options = {};
 		setSnapParameterOnOptions(ruler, options);

--- a/src/main.js
+++ b/src/main.js
@@ -137,10 +137,11 @@ function onEntityLeftDragStart(wrapped, event) {
 	const ruler = canvas.controls.ruler;
 	ruler.draggedEntity = this;
 	const entityCenter = getEntityCenter(this);
-	ruler.rulerOffset = {
-		x: 0,
-		y: 0,
-	};
+	const isV11 = game.release.generation === 11;
+    ruler.rulerOffset = {
+    	x: isV11 ? entityCenter.x - event.interactionData.origin.x : 0,
+      	y: isV11 ? entityCenter.y - event.interactionData.origin.y : 0,
+    };
 	if (game.settings.get(settingsKey, "autoStartMeasurement")) {
 		let options = {};
 		setSnapParameterOnOptions(ruler, options);

--- a/src/util.js
+++ b/src/util.js
@@ -157,7 +157,8 @@ export function getAreaFromPositionAndShape(position, shape) {
 		let y = position.y + space.y;
 		if (isCanvasHex()) {
 			let shiftedRow;
-			if (canvas.grid.even) shiftedRow = 1;
+			// v12 ?? v11
+			if (canvas.grid?.even ?? canvas.grid.grid.options.even) shiftedRow = 1;
 			else shiftedRow = 0;
 			if (canvas.grid.columnar) {
 				if (space.x % 2 !== 0 && position.x % 2 !== shiftedRow) {

--- a/src/util.js
+++ b/src/util.js
@@ -160,7 +160,7 @@ export function getAreaFromPositionAndShape(position, shape) {
 			// v12 ?? v11
 			if (canvas.grid?.even ?? canvas.grid.grid.options.even) shiftedRow = 1;
 			else shiftedRow = 0;
-			if (canvas.grid.columnar) {
+			if (canvas.grid.grid.columnar) {
 				if (space.x % 2 !== 0 && position.x % 2 !== shiftedRow) {
 					y += 1;
 				}

--- a/src/util.js
+++ b/src/util.js
@@ -157,9 +157,9 @@ export function getAreaFromPositionAndShape(position, shape) {
 		let y = position.y + space.y;
 		if (isCanvasHex()) {
 			let shiftedRow;
-			if (canvas.grid.grid.options.even) shiftedRow = 1;
+			if (canvas.grid.even) shiftedRow = 1;
 			else shiftedRow = 0;
-			if (canvas.grid.grid.columnar) {
+			if (canvas.grid.columnar) {
 				if (space.x % 2 !== 0 && position.x % 2 !== shiftedRow) {
 					y += 1;
 				}


### PR DESCRIPTION
This PR addresses the offset issue described in [this comment](https://github.com/manuelVo/foundryvtt-drag-ruler/pull/329#issuecomment-2254205254).

Changes made:
- Removed double correction in ruler.rulerOffset.
- Checking for grid even in canvas.grid.even (was canvas.grid.grid.options.even)